### PR TITLE
Migrate project Java 11 to java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.release>25</maven.compiler.release>
         <dropwizard.version>4.0.2</dropwizard.version>
         <h2.version>2.2.224</h2.version>
         <mainClass>org.ministry.magic.WizardRegistryApplication</mainClass>
@@ -119,7 +119,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>25</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Summary

**Migrated the project from Java 11 to Java 25.**

### Changes

- Updated Maven compiler source, target, and release versions to 25.

- Updated Maven Compiler Plugin release version to 25.

- Updated GitHub Actions CI workflow to use JDK 25.

### Verification

- Project builds successfully.

- Tests pass successfully using Java 25.